### PR TITLE
Problem: macOS metadata files break import

### DIFF
--- a/Sanimal FX/src/main/java/model/analysis/SanimalAnalysisUtils.java
+++ b/Sanimal FX/src/main/java/model/analysis/SanimalAnalysisUtils.java
@@ -52,7 +52,8 @@ public class SanimalAnalysisUtils
 	 */
 	public static boolean fileIsImage(File file)
 	{
-		return StringUtils.endsWithAny(file.getAbsolutePath(), "jpg", "jpeg", "JPEG", "JPG");
+		return StringUtils.endsWithAny(file.getAbsolutePath(), "jpg", "jpeg", "JPEG", "JPG")
+				&& !StringUtils.startsWith(file.getName(), ".");
 
 		// This checks to see if the file is purely an image, we want JPGs only!
 		/*


### PR DESCRIPTION
These are files like `._IMG001.JPG`.

Solution: Just ignore any files which start with period (`.`) for now.