### PR TITLE
Problem: Don't want to leak GitHub API key during builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,9 @@ script:
 
 deploy:
   provider: releases
-  api_key: $GITHUB_API_KEY
+  api_key: "GITHUB OAUTH TOKEN"
   file: "target/SanimalFX-1.0-SNAPSHOT-jar-with-dependencies.jar"
   skip_cleanup: true
+  draft: true
   on:
     tags: true
-    all_branches: true


### PR DESCRIPTION
Solution: Use the GitHub OAuth token method.